### PR TITLE
m-allanson/49 killing a host

### DIFF
--- a/src/app/controllers/boot.js
+++ b/src/app/controllers/boot.js
@@ -1,0 +1,17 @@
+/**
+ * NoiseBox
+ * boot.js
+ *
+ * Boot route controller, allows the client side code to redirect with a 
+ * flash message displayed after the redirect
+ */
+
+var server = require("./../../server");
+var app = server.app;
+var templateOptions = require("./../middleware/template-options");
+
+app.get('/boot', templateOptions(), function(req, res, next){
+    req.session.flashMessage = req.query.m;
+    res.redirect("/");
+    return;
+});

--- a/src/app/controllers/host.js
+++ b/src/app/controllers/host.js
@@ -157,15 +157,17 @@ var HostController = {
             nb.removeHost(socket.id);
 
             // that was the last host so boot all the users out
+            log.info("removed hosts users",{socketid:socket.id,noiseboxid:nb.id});
             if (nb.hosts.length < 1) {
-
                 nb.users.each(function(user){
-                    console.log('socket is', user.socket);
-
                     user.get('socket').emit(server.constants.SERVER_BOOT_CLIENT,{
                         message: 'The host no longer exists'
                     });
                 });
+
+                // now destroy the noisebox
+                console.log('removed noisebox',{noiseboxid:nb.id});
+                model.removeNoiseBox(nb.id);
             }
         }
     }

--- a/src/app/controllers/host.js
+++ b/src/app/controllers/host.js
@@ -154,8 +154,19 @@ var HostController = {
         if ( nb.hostExists(socket.id) ) {
 
             log.info("removed host",{socketid:socket.id,noiseboxid:nb.id});
-
             nb.removeHost(socket.id);
+
+            // that was the last host so boot all the users out
+            if (nb.hosts.length < 1) {
+
+                nb.users.each(function(user){
+                    console.log('socket is', user.socket);
+
+                    user.get('socket').emit(server.constants.SERVER_BOOT_CLIENT,{
+                        message: 'The host no longer exists'
+                    });
+                });
+            }
         }
     }
 };

--- a/src/app/controllers/user.js
+++ b/src/app/controllers/user.js
@@ -14,6 +14,7 @@ var constants = server.constants;
 var moment = require("./../lib/moment");
 var templateOptions = require("./../middleware/template-options");
 var stats = require("./../middleware/stats");
+var cacheNuker = require("./../middleware/cache-nuker");
 var AbstractController = require("./abstract.js");
 var _ = require("underscore");
 var log = require("../lib/log");
@@ -24,7 +25,7 @@ var UserController = {
 
         // Map route to middleware and rendering function:
 
-        app.get("/:id",templateOptions(),stats(),function (req,res) {
+        app.get("/:id",templateOptions(),stats(),cacheNuker(),function (req,res) {
 
             var id = req.params.id;
 

--- a/src/app/middleware/cache-nuker.js
+++ b/src/app/middleware/cache-nuker.js
@@ -1,0 +1,9 @@
+module.exports = function () {
+
+    return function (req,res,next) {
+        res.header("Cache-Control","no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0");
+        res.header("Expires","0");
+        res.header("Pragma","no-cache");
+        next();
+    };
+};

--- a/src/public/js/UserClient.js
+++ b/src/public/js/UserClient.js
@@ -344,7 +344,7 @@ define(["constants","AbstractClient","jquery","underscore", "scrollspy", "tabs",
 
 
         bootClient: function(e) {
-            console.log('Got boot message', arguments);
+            window.location = '/boot/?m=The host has left, and kicked you out!';
         },
 
 

--- a/src/public/js/UserClient.js
+++ b/src/public/js/UserClient.js
@@ -49,6 +49,7 @@ define(["constants","AbstractClient","jquery","underscore", "scrollspy", "tabs",
             this.on(Const.SERVER_SOCKET_CONNECT,this.detectTransport);
 
             this.on(Const.SERVER_ADD_TRACK,this.onTrackQueued);
+            this.on(Const.SERVER_BOOT_CLIENT,this.bootClient);
             this.on(Const.HOST_TRACK_PLAYING,this.onTrackPlaying);
             this.on(Const.HOST_TRACK_COMPLETE,this.onTrackComplete);
 
@@ -339,6 +340,11 @@ define(["constants","AbstractClient","jquery","underscore", "scrollspy", "tabs",
             if (transport !== 'websocket') {
                 this.createFlashMessage("Your connection to noisebox isn't great, it could be improved by using a modern browser or connecting via wifi");
             }
+        },
+
+
+        bootClient: function(e) {
+            console.log('Got boot message', arguments);
         },
 
 

--- a/src/public/js/const.js
+++ b/src/public/js/const.js
@@ -53,6 +53,7 @@ var Const = {
     SERVER_NOISE_BOX_STATS_UPDATED : "noiseBoxStatsUpdated",
     SERVER_ADD_TRACK : "addTrack",
     SERVER_REMOVE_TRACK : "removeTrack",
+    SERVER_BOOT_CLIENT : 'bootClient',
 
     // Custom client > server socket events
 

--- a/src/server.js
+++ b/src/server.js
@@ -74,6 +74,7 @@ if (env === 'testing') {
 var HomeController = require("./app/controllers/home");
 var HostController = require("./app/controllers/host");
 var UserController = require("./app/controllers/user");
+var BootController = require("./app/controllers/boot");
 
 HomeController();
 HostController.init();


### PR DESCRIPTION
Boot out all clients when the last host is closed, ensuring the noisebox is destroyed properly.  Clients will be redirected to the home page with a flash message giving the details.
